### PR TITLE
PIWIK-8 : Make the default piwik script conformant with the CNIL recommandations

### DIFF
--- a/webapp/WEB-INF/templates/skin/plugins/piwik/piwik_analytics.html
+++ b/webapp/WEB-INF/templates/skin/plugins/piwik/piwik_analytics.html
@@ -1,11 +1,24 @@
 <!-- Piwik -->
 <script type="text/javascript">
     var _paq = _paq || [];
+    _paq.push([function() {
+      var self = this;
+      function getOriginalVisitorCookieTimeout() {
+        var now = new Date(),
+        nowTs = Math.round(now.getTime() / 1000),
+        visitorInfo = self.getVisitorInfo();
+        var createTs = parseInt(visitorInfo[2]);
+        var cookieTimeout = 33696000; // 13 mois en secondes
+        var originalTimeout = createTs + cookieTimeout - nowTs;
+        return originalTimeout;
+      }
+      this.setVisitorCookieTimeout(getOriginalVisitorCookieTimeout());
+    }]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
     (function(){ var u=(("https:" == document.location.protocol) ? "${server_https_url}" : "${server_http_url}");
     _paq.push(['setSiteId', ${site_id}]);
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=true; g.src=u+'piwik.js';
     s.parentNode.insertBefore(g,s); })();
 </script>


### PR DESCRIPTION
The french CNIL states that to be exempt from notifying the user of cookie
use, the PIWIK cookie should not be prorogated on each visit (see
http://www.cnil.fr/fileadmin/documents/approfondir/dossier/internet/Configuration_piwik.pdf)
